### PR TITLE
Add IS number format to price

### DIFF
--- a/gulpconfig-defaults.js
+++ b/gulpconfig-defaults.js
@@ -157,6 +157,7 @@ module.exports = (externalConfig) => {
     imageFields: ['image'],
     datetimeFields: ['datetime', 'date', 'time'],
     splitTagFields: ['socialMediaHandles'],
+    numberFields: ['price'],
   }, config.contentful)
 
   // STATIC

--- a/utils/contentful/transform.js
+++ b/utils/contentful/transform.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const marked = require('marked')
 const moment = require('moment')
+const numeral = require('numeral')
 
 module.exports = (entries, config) => {
   const ret = {}
@@ -26,6 +27,20 @@ module.exports = (entries, config) => {
     })
 
     return sizes
+  }
+
+  const processNumberFields = (number) => {
+    numeral.language('is', {
+      delimiters: {
+        thousands: '.',
+        decimal: ',',
+      },
+    })
+    numeral.language('is')
+
+    return {
+      is: (number < 999) ? number : numeral(number).format('0,0'),
+    }
   }
 
   const processSplitTags = (splitTags) => {
@@ -84,6 +99,8 @@ module.exports = (entries, config) => {
         obj[field] = processImage(value)
       } else if (config.contentful.splitTagFields.indexOf(field) !== -1) {
         obj[field] = processSplitTags(value)
+      } else if (config.contentful.numberFields.indexOf(field) !== -1) {
+        obj[field] = processNumberFields(value)
       } else if (isMarkdown) {
         obj[field] = marked(value)
       } else if (Array.isArray(value)) {


### PR DESCRIPTION
The price field (and possible future number fields if added) is now formatted to Icelandic convention

```
10.000
```

Used in https://github.com/KolibriDev/godigital.is/pull/20
